### PR TITLE
Add Dockerfile for markdownlint-cli 0.31.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Build
+
+on:
+  push:
+    branches: [develop]
+  release:
+    types: [published]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3
+
+      # Extract metadata (tags, labels) for Docker
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # renovate: tag=v4
+        with:
+          images: swissgrc/azure-pipelines-markdownlint
+          tags: |
+            type=ref,event=tag
+            type=ref,event=pr
+            # set unstable tag for develop branch
+            type=raw,value=unstable,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
+
+      # Build Docker image with Buildx
+      - name: Build Docker image
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # renovate: tag=v3
+        with:
+          context: .
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # Scan Docker image
+      - name: Scan Docker image
+        uses: aquasecurity/trivy-action@4b9b6fb4ef28b31450391a93ade098bb00de584e # renovate: tag=0.3.0
+        with:
+          image-ref: ${{ steps.meta.outputs.tags }}
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+
+      # Publish scan report to GitHub
+      - name: Publish scan report to GitHub        
+        uses: github/codeql-action/upload-sarif@a6611b86918424d4588efe7d6dbe18fe52d42518 # renovate: tag=v1
+        if: ${{ always() }}
+        with:
+          sarif_file: trivy-results.sarif
+
+      # Login to Docker registry if not PR build
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # renovate: tag=v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Publish Docker image for CI builds if not PR build
+      - name: Push container image
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # renovate: tag=v3
+        if: github.event_name != 'pull_request'
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:18.4.0-bullseye
+
+LABEL org.opencontainers.image.vendor="Swiss GRC AG"
+LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
+LABEL org.opencontainers.image.title="azure-pipelines-markdownlint"
+LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker-azure-pipelines-markdownlint"
+
+# Make sure to fail due to an error at any stage in shell pipes
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# markdownlint-cli
+
+# renovate: datasource=npm depName=markdownlint-cli
+ENV MARKDOWNLINT_VERSION=0.31.1
+
+RUN npm install -g markdownlint-cli@${MARKDOWNLINT_VERSION} && \
+  npm cache clean --force && \
+  # Smoke test
+  markdownlint --version

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
-# markdownlint-cli
-Docker image for running markdownlint-cli
+# Docker image for running markdownlint-cli in Azure Pipelines container jobs
+
+<!-- markdownlint-disable MD013 -->
+[![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/swissgrc/docker-azure-pipelines-markdownlint/blob/main/LICENSE) [![Build](https://img.shields.io/docker/cloud/build/swissgrc/azure-pipelines-markdownlint.svg?style=flat-square)](https://hub.docker.com/r/swissgrc/azure-pipelines-markdownlint/builds) [![Pulls](https://img.shields.io/docker/pulls/swissgrc/azure-pipelines-markdownlint.svg?style=flat-square)](https://hub.docker.com/r/swissgrc/azure-pipelines-markdownlint) [![Stars](https://img.shields.io/docker/stars/swissgrc/azure-pipelines-markdownlint.svg?style=flat-square)](https://hub.docker.com/r/swissgrc/azure-pipelines-markdownlint)
+<!-- markdownlint-restore -->
+
+Docker image to run [markdownlint] commands in [Azure Pipelines container jobs].
+
+## Usage
+
+This container can be used to run markdownlint commands in [Azure Pipelines container jobs].
+
+### Azure Pipelines Container Job
+
+To use the image in an Azure Pipelines Container Job add the following task use it with the `container` property.
+
+The following example shows the container used for linting the repository:
+
+```yaml
+- stage: Build
+  jobs:
+  - job: Lint
+    steps:
+    - bash: |
+        markdownlint --output /markdownlint.json --json --config /.markdownlint.json /docs
+      target: swissgrc/azure-pipelines-markdownlint:latest
+```
+
+### Tags
+
+<!-- markdownlint-disable MD013 -->
+| Tag      | Description                                                                                       | Base Image             | Markdownlint-Cli | Size                                                                                                                                  |
+|----------|---------------------------------------------------------------------------------------------------|------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| latest   | Latest stable release (from `main` branch)                                                        | node:18.4.0-bullseye   | 0.31.1           | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-markdownlint/latest?style=flat-square)   |
+| unstable | Latest unstable release (from `develop` branch)                                                   | node:18.4.0-bullseye   | 0.31.1           | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-markdownlint/unstable?style=flat-square) |
+| 0.31.1   | [markdownlint-cli 0.31.1](https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.31.1) | node:18.4.0-bullseye   | 0.31.1           | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-markdownlint/0.31.1?style=flat-square)   |
+<!-- markdownlint-restore -->
+
+### Configuration
+
+These environment variables are supported:
+
+| Environment variable   | Default value        | Description                                                      |
+|------------------------|----------------------|------------------------------------------------------------------|
+| MARKDOWNLINT_VERSION   | `0.31.1`             | Version of markdownlint-cli installed in the image.              |
+
+[markdownlint]: https://github.com/igorshubovych/markdownlint-cli
+[Azure Pipelines container jobs]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases


### PR DESCRIPTION
Adds Dockerfile for markdownlint-cli 0.31.1 with pipeline to build, scan and publish the image to Docker Hub.